### PR TITLE
Add streaming Completions method

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters-settings:
   gocognit:
     # Minimal code complexity to report
     # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
+    min-complexity: 30
 
   gocritic:
     # Settings passed to gocritic.

--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func (c *Client) post(ctx context.Context, path string, payload any) ([]byte, er
 	return io.ReadAll(resp.Body)
 }
 
-const bufferSize = 2048
+const bufferSize = 4096
 
 func (c *Client) postStream(ctx context.Context, path string, payload any) (<-chan []byte, <-chan error, error) {
 	var b, err = json.Marshal(payload)

--- a/client.go
+++ b/client.go
@@ -127,7 +127,7 @@ func (c *Client) postStream(ctx context.Context, path string, payload any) (<-ch
 		defer close(errCh)
 
 		for {
-			var msg = make([]byte, 1024)
+			var msg = make([]byte, 2048)
 			_, err = resp.Body.Read(msg)
 
 			switch {

--- a/completions.go
+++ b/completions.go
@@ -161,7 +161,7 @@ func (c *Client) CreateStreamingCompletion(ctx context.Context, cr *CompletionRe
 				var events [][]byte
 				var done bool
 				events, err = parseEvents(b)
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					done = true
 				}
 

--- a/completions.go
+++ b/completions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 
@@ -169,7 +168,6 @@ func (c *Client) CreateStreamingCompletion(ctx context.Context, cr *CompletionRe
 					var resp = &CompletionResponse[models.Completion]{}
 
 					if err = json.Unmarshal(event, resp); err != nil {
-						fmt.Println(string(event))
 						errCh <- err
 						return
 					}

--- a/completions.go
+++ b/completions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -168,6 +169,7 @@ func (c *Client) CreateStreamingCompletion(ctx context.Context, cr *CompletionRe
 					var resp = &CompletionResponse[models.Completion]{}
 
 					if err = json.Unmarshal(event, resp); err != nil {
+						fmt.Println(string(event))
 						errCh <- err
 						return
 					}

--- a/completions.go
+++ b/completions.go
@@ -3,6 +3,9 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"strings"
 
 	"github.com/fabiustech/openai/models"
 	"github.com/fabiustech/openai/objects"
@@ -45,10 +48,6 @@ type CompletionRequest[T models.Completion | models.FineTunedModel] struct {
 	// and ensure that you have reasonable settings for max_tokens and stop.
 	// Defaults to 1.
 	N int `json:"n,omitempty"`
-	// Steam specifies Whether to stream back partial progress. If set, tokens will be sent as data-only server-sent
-	// events as they become available, with the stream terminated by a data: [DONE] message.
-	// Defaults to false.
-	Stream bool `json:"stream,omitempty"`
 	// LogProbs specifies to include the log probabilities on the logprobs most likely tokens, as well the chosen
 	// tokens. For example, if logprobs is 5, the API will return a list of the 5 most likely tokens. The API will
 	// always return the logprob of the sampled token, so there may be up to logprobs+1 elements in the response.
@@ -97,7 +96,7 @@ type CompletionRequest[T models.Completion | models.FineTunedModel] struct {
 type CompletionChoice struct {
 	Text         string         `json:"text"`
 	Index        int            `json:"index"`
-	FinishReason string         `json:"finish_reason"`
+	FinishReason *string        `json:"finish_reason,omitempty"`
 	LogProbs     *LogprobResult `json:"logprobs"`
 }
 
@@ -116,7 +115,7 @@ type CompletionResponse[T models.Completion | models.FineTunedModel] struct {
 	Created uint64              `json:"created"`
 	Model   T                   `json:"model"`
 	Choices []*CompletionChoice `json:"choices"`
-	Usage   *Usage              `json:"usage"`
+	Usage   *Usage              `json:"usage,omitempty"`
 }
 
 // CreateCompletion creates a completion for the provided prompt and parameters.
@@ -132,6 +131,92 @@ func (c *Client) CreateCompletion(ctx context.Context, cr *CompletionRequest[mod
 	}
 
 	return resp, nil
+}
+
+type streamingCompletion struct {
+	Stream bool `json:"stream"`
+	*CompletionRequest[models.Completion]
+}
+
+func (c *Client) CreateStreamingCompletion(ctx context.Context, cr *CompletionRequest[models.Completion]) (<-chan *CompletionResponse[models.Completion], <-chan error, error) {
+	var receive, errs, err = c.postStream(ctx, routes.Completions, &streamingCompletion{
+		Stream:            true,
+		CompletionRequest: cr,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var resps = make(chan *CompletionResponse[models.Completion])
+	var errCh = make(chan error)
+
+	go func() {
+		defer close(resps)
+		defer close(errCh)
+
+		for {
+			select {
+			case b := <-receive:
+				var events [][]byte
+				var done bool
+				events, err = parseEvents(b)
+				if err == io.EOF {
+					done = true
+				}
+
+				for _, event := range events {
+					var resp = &CompletionResponse[models.Completion]{}
+
+					if err = json.Unmarshal(event, resp); err != nil {
+						errCh <- err
+						return
+					}
+
+					resps <- resp
+				}
+
+				if done {
+					return
+				}
+			case err = <-errs:
+				errCh <- err
+				return
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+	}()
+
+	return resps, errCh, nil
+}
+
+const eventPrefix = "data: "
+const eof = "[DONE]"
+
+var ErrBadPrefix = errors.New("unexpected event received")
+
+func parseEvents(b []byte) ([][]byte, error) {
+	if !strings.HasPrefix(string(b), eventPrefix) {
+		return nil, ErrBadPrefix
+	}
+
+	var split = strings.Split(string(b), eventPrefix)
+	var out [][]byte
+
+	var err error
+
+	for _, event := range split[1:] {
+		var msg = strings.TrimRight(event, "\r\n\x00")
+		if msg == eof {
+			err = io.EOF
+			continue
+		}
+
+		out = append(out, []byte(msg))
+	}
+
+	return out, err
 }
 
 // CreateFineTunedCompletion creates a completion for the provided prompt and parameters, using a fine-tuned model.

--- a/completions_test.go
+++ b/completions_test.go
@@ -1,0 +1,57 @@
+package openai
+
+import (
+	"io"
+	"testing"
+)
+
+func TestParseEvents(t *testing.T) {
+	var tcs = []struct {
+		in  []byte
+		out [][]byte
+		err error
+	}{
+		{
+			in:  []byte(`bad-prefix: {}`),
+			err: ErrBadPrefix,
+		},
+		{
+			in: []byte(`data: {}`),
+			out: [][]byte{
+				[]byte(`data: {}`),
+			},
+		},
+		{
+			in: []byte(`data: {}
+
+data: {}
+
+`),
+			out: [][]byte{
+				[]byte(`data: {}`),
+				[]byte(`data: {}`),
+			},
+		},
+		{
+			in: []byte(`data: {}
+
+data: [DONE]
+
+`),
+			out: [][]byte{
+				[]byte(`data: {}`),
+			},
+			err: io.EOF,
+		},
+	}
+
+	for _, tc := range tcs {
+		var out, err = parseEvents(tc.in)
+		if len(out) != len(tc.out) {
+			t.Fatal("mismatched event counts")
+		}
+		if err != tc.err {
+			t.Fatalf("expected err=%v, got err=%v", tc.err, err)
+		}
+	}
+}

--- a/completions_test.go
+++ b/completions_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"errors"
 	"io"
 	"testing"
 )
@@ -50,7 +51,7 @@ data: [DONE]
 		if len(out) != len(tc.out) {
 			t.Fatal("mismatched event counts")
 		}
-		if err != tc.err {
+		if !errors.Is(err, io.EOF) {
 			t.Fatalf("expected err=%v, got err=%v", tc.err, err)
 		}
 	}

--- a/completions_test.go
+++ b/completions_test.go
@@ -51,7 +51,7 @@ data: [DONE]
 		if len(out) != len(tc.out) {
 			t.Fatal("mismatched event counts")
 		}
-		if !errors.Is(err, io.EOF) {
+		if !errors.Is(err, tc.err) {
 			t.Fatalf("expected err=%v, got err=%v", tc.err, err)
 		}
 	}


### PR DESCRIPTION
Removes the `Stream` flag from the CompletionsRequest and creates a separate method which supports returning streamed events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/openai/5)
<!-- Reviewable:end -->
