### PR TITLE
[Breaking Change] Modify returned errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -273,7 +273,7 @@ func interpretResponse(resp *http.Response) error {
 		if err != nil {
 			return fmt.Errorf("error, HTTP status code: %d", resp.StatusCode)
 		}
-		var er = &errorResponse{}
+		var er = &responseError{}
 		if err = json.Unmarshal(b, er); err != nil || er.Err == nil {
 			return fmt.Errorf("error, HTTP status code: %d, msg: %s", resp.StatusCode, string(b))
 		}

--- a/client.go
+++ b/client.go
@@ -271,14 +271,14 @@ func interpretResponse(resp *http.Response) error {
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
 		var b, err = io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("error, status code: %d", resp.StatusCode)
+			return fmt.Errorf("error, HTTP status code: %d", resp.StatusCode)
 		}
 		var er = &errorResponse{}
-		if err = json.Unmarshal(b, er); err != nil || er.Error == nil {
-			return fmt.Errorf("error, status code: %d, msg: %s", resp.StatusCode, string(b))
+		if err = json.Unmarshal(b, er); err != nil || er.Err == nil {
+			return fmt.Errorf("error, HTTP status code: %d, msg: %s", resp.StatusCode, string(b))
 		}
 
-		return er.Error
+		return er
 	}
 
 	return nil

--- a/error.go
+++ b/error.go
@@ -7,7 +7,21 @@ import (
 
 // errorResponse wraps the returned error.
 type errorResponse struct {
-	Error *Error `json:"error,omitempty"`
+	ID  string `json:"id"`
+	Err *Error `json:"error,omitempty"`
+}
+
+// Error implements the error interface.
+func (e *errorResponse) Error() string {
+	return fmt.Sprintf("Request ID: %s, Code: %v, Message: %s, Type: %s, Param: %v", e.ID, e.Err.Code, e.Err.Message, e.Err.Type, e.Err.Param)
+}
+
+// Retryable returns true if the error is retryable.
+func (e *errorResponse) Retryable() bool {
+	if e.Err.Code >= http.StatusInternalServerError {
+		return true
+	}
+	return e.Err.Code == http.StatusTooManyRequests
 }
 
 // Error represents an error response from the API.

--- a/error.go
+++ b/error.go
@@ -5,19 +5,19 @@ import (
 	"net/http"
 )
 
-// errorResponse wraps the returned error.
-type errorResponse struct {
+// responseError wraps the returned error.
+type responseError struct {
 	ID  string `json:"id"`
 	Err *Error `json:"error,omitempty"`
 }
 
 // Error implements the error interface.
-func (e *errorResponse) Error() string {
+func (e *responseError) Error() string {
 	return fmt.Sprintf("Request ID: %s, Code: %v, Message: %s, Type: %s, Param: %v", e.ID, e.Err.Code, e.Err.Message, e.Err.Type, e.Err.Param)
 }
 
 // Retryable returns true if the error is retryable.
-func (e *errorResponse) Retryable() bool {
+func (e *responseError) Retryable() bool {
 	if e.Err.Code >= http.StatusInternalServerError {
 		return true
 	}


### PR DESCRIPTION
This change also captures the request ID in the error, to make it easier to debug and report issues to OpenAI.

Should have a pretty low chance of breaking any actual uses unless someone was type asserting the returned errors (can't find any instances on GH).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/openai/13)
<!-- Reviewable:end -->
