### PR TITLE
Get rid of responseErr since there is no ID returned, etc.

### DIFF
--- a/client.go
+++ b/client.go
@@ -273,12 +273,12 @@ func interpretResponse(resp *http.Response) error {
 		if err != nil {
 			return fmt.Errorf("error, HTTP status code: %d", resp.StatusCode)
 		}
-		var er = &responseError{}
-		if err = json.Unmarshal(b, er); err != nil || er.Err == nil {
+		err = &Error{}
+		if json.Unmarshal(b, err) != nil {
 			return fmt.Errorf("error, HTTP status code: %d, msg: %s", resp.StatusCode, string(b))
 		}
 
-		return er
+		return err
 	}
 
 	return nil

--- a/error.go
+++ b/error.go
@@ -5,25 +5,6 @@ import (
 	"net/http"
 )
 
-// responseError wraps the returned error.
-type responseError struct {
-	ID  string `json:"id"`
-	Err *Error `json:"error,omitempty"`
-}
-
-// Error implements the error interface.
-func (e *responseError) Error() string {
-	return fmt.Sprintf("Request ID: %s, Code: %v, Message: %s, Type: %s, Param: %v", e.ID, e.Err.Code, e.Err.Message, e.Err.Type, e.Err.Param)
-}
-
-// Retryable returns true if the error is retryable.
-func (e *responseError) Retryable() bool {
-	if e.Err.Code >= http.StatusInternalServerError {
-		return true
-	}
-	return e.Err.Code == http.StatusTooManyRequests
-}
-
 // Error represents an error response from the API.
 type Error struct {
 	Code    int     `json:"code"`
@@ -39,7 +20,7 @@ func (e *Error) Error() string {
 
 // Retryable returns true if the error is retryable.
 func (e *Error) Retryable() bool {
-	if e.Code >= http.StatusInternalServerError {
+	if e.Code >= http.StatusInternalServerError || e.Code == 0 {
 		return true
 	}
 	return e.Code == http.StatusTooManyRequests


### PR DESCRIPTION
We made the incorrect assumption there would be a request ID on 5xx errors, etc. and also OpenAI likes to return Code 0 sometimes when it hits an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/openai/14)
<!-- Reviewable:end -->
